### PR TITLE
webpack dependency: ^1.14.0 -> ^2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "mocha": "^3.2.0",
     "react-scripts": "^1.0.7",
     "react-test-render": "^1.0.3",
-    "webpack": "^1.14.0",
+    "webpack": "^2.2.0",
     "webpack-dev-server": "^1.16.2"
   },
   "dependencies": {


### PR DESCRIPTION
Webpack upgrade necessary to avoid long `TypeError: Cannot read property 'request' of undefined` error when doing `npm start`.

@Lukeghenco 